### PR TITLE
Allow user to set additional class names

### DIFF
--- a/app/views/kaminari/_paginator.html.erb
+++ b/app/views/kaminari/_paginator.html.erb
@@ -6,8 +6,9 @@
     remote:        data-remote
     paginator:     the paginator that renders the pagination tags inside
 -%>
+<% html ||= {} %>
 <%= paginator.render do -%>
-  <nav class="pagination">
+  <nav class="pagination<%= " #{html[:class]}" if html.has_key?(:class) %>">
   <% if total_pages > 0 -%>
     <ul>
       <%= first_page_tag unless current_page.first? %>


### PR DESCRIPTION
This tweak will allow users to quickly add class names to the main nav element. This can be used to quickly change the size of the pagination nav or change the alignment.

For example:

``` ruby
<%= paginate @products, :html => {:class => "pagination-mini pagination-right"} %>
```

Generates:

``` html
<nav class="pagination pagination-mini pagination-right">
```
